### PR TITLE
fix(verify_embed): missing `sigt` should fail as invalid signature

### DIFF
--- a/lib/venndr_sdk/plug/verify_embed_signature.ex
+++ b/lib/venndr_sdk/plug/verify_embed_signature.ex
@@ -74,7 +74,7 @@ defmodule VenndrSDK.Plug.VerifyEmbedSignature do
   defp get_sigt(conn),
     do:
       conn.query_params
-      |> Map.get("sigt", "0")
+      |> Map.get("sigt", "")
       |> Integer.parse()
       |> (case do
             {sigt, _} -> sigt

--- a/test/plug/verify_embed_signature_test.exs
+++ b/test/plug/verify_embed_signature_test.exs
@@ -55,8 +55,8 @@ defmodule VenndrSDK.Plug.VerifyEmbedSignatureTest do
     {:ok,
      %{
        default_opts: default_opts,
-       invalid_paths: [doctored_path, missing_sigv, missing_sig, partial_sig],
-       expired_signatures: [missing_sigt, expired_signature],
+       invalid_paths: [doctored_path, missing_sigv, missing_sigt, missing_sig, partial_sig],
+       expired_signatures: [expired_signature],
        valid_path: valid_path
      }}
   end


### PR DESCRIPTION
passing in a default value of `"0"` returns a request expired error, which will still fail an incoming request, but is misleading. removing the default maps the error to invalid signature, which is a much more representative outcome.